### PR TITLE
Add new short flag for ascii

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,9 @@ catpic
 # Ascii Usage
 catpic --ascii
 
+# Alternatively use the short flag
+catpic -a
+
 # Custom Width Ascii
 catpic --ascii 50
 

--- a/cat.sh
+++ b/cat.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-if [ "$1" == "--ascii" ]
+if [ "$1" == "--ascii" ] || [ "$1" == "-a" ]
 then
 if [ -z "$2" ]
 then

--- a/catpic.sh
+++ b/catpic.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-if [ "$1" == "--ascii" ]
+if [ "$1" == "--ascii" ] || [ "$1" == "-a" ]
 then
 if [ -z "$2" ]
 then


### PR DESCRIPTION
Currently you need to use the long `--ascii` tag. This changes that so
you can use a shorter `-a` tag instead.

For example

```bash
catpic -a
```

Ref issue #2